### PR TITLE
Normalize rand function names

### DIFF
--- a/src/rand.rs
+++ b/src/rand.rs
@@ -63,18 +63,17 @@ impl Rng {
         Self::default()
     }
 
-    #[cfg_attr(feature = "cargo-clippy", allow(should_implement_trait))]
-    pub fn next(&mut self) -> u32 {
+    pub fn gen_int(&mut self) -> u32 {
         self.pcg32()
     }
 
-    pub fn next_in_range(&mut self, min: u32, max: u32) -> u32 {
+    pub fn gen_int_interval(&mut self, min: u32, max: u32) -> u32 {
         (self.pcg32() % (max - min)) + min
     }
 
-    pub fn next_double(&mut self) -> f64 {
+    pub fn gen_double_interval_unit(&mut self) -> f64 {
         let max = f64::from(u32::MAX);
-        let n = f64::from(self.next());
+        let n = f64::from(self.gen_int());
         n / max
     }
 }
@@ -90,7 +89,7 @@ mod tests {
         let mut rng = Rng::new();
         let mut numbers = vec![];
         for _ in 0..1_000_000 {
-            numbers.push(rng.next());
+            numbers.push(rng.gen_int());
         }
         let (min, max) = {
             (numbers.iter().cloned().min().expect("minimum"), numbers.iter().cloned().max().expect("maximum"))
@@ -108,7 +107,7 @@ mod tests {
         let mut values = vec![0; capacity];
         let end = capacity * 25;
         for _ in 0..end {
-            let index = rng.next() as usize % values.len();
+            let index = rng.gen_int() as usize % values.len();
             values[index] += 1;
         }
 

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -50,6 +50,7 @@ impl Rng {
         v as u32
     }
 
+    /// Creates a new pseudo-random with a custom seed.
     pub fn seed_with(seed: u64) -> Self {
         // We xor the seed with a randomly chosen number to avoid ending up with
         // a 0 state which would be bad.
@@ -59,18 +60,22 @@ impl Rng {
         }
     }
 
+    /// Creates a new pseudo-random number generator with default seed.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Generates an integer.
     pub fn gen_int(&mut self) -> u32 {
         self.pcg32()
     }
 
+    /// Generates an integer between `min` (included) and `max` (excluded), i.e. [min, max).
     pub fn gen_int_interval(&mut self, min: u32, max: u32) -> u32 {
         (self.pcg32() % (max - min)) + min
     }
 
+    /// Generates a floating-point number between 0.0 and 1.0, both included.
     pub fn gen_double_interval_unit(&mut self) -> f64 {
         let max = f64::from(u32::MAX);
         let n = f64::from(self.gen_int());


### PR DESCRIPTION
@RAttab told me the name `next_double()` does not specify the intent of generating only between `0.0` and `1.0` so I found a new name and I took this opportunity to normalize the other names as well (clippy is now giving trouble with `cfg_attr`, so that's a good clean-up).
Please tell me what you think of the new name.
I have the feeling it's a bit long.
An alternative to `interval_unit` would be `normalized`.
If you have any other suggestions, I'd like to hear them.
Thanks.